### PR TITLE
Checks in orchestrate client

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "express": "~4.13.1",
     "hbs": "~3.1.0",
     "morgan": "~1.6.1",
+    "orchestrate": "~0.5.1",
     "serve-favicon": "~2.3.0"
   }
 }


### PR DESCRIPTION
Addresses this one:

```
$ npm start

> bfhApp@0.0.0 start /home/rj/Documents/Repositories/rjz/city-sound
> node ./bin/www


module.js:340
    throw err;
          ^
Error: Cannot find module 'orchestrate'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
```
